### PR TITLE
Differential privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,43 @@ The [GAN example from dm-haiku](https://github.com/deepmind/dm-haiku/blob/4ae60f
 To run the auction experiment with specific parameters:
 
 ```
-  python algnet.py with num_steps=100 misr_updates=50 misr_reinit_iv=500 misr_reinit_lim=1000 batch_size=100 bidders=5 items=10 net_width=200 net_depth=7 num_test_samples=20
+python algnet.py with num_steps=100 misr_updates=50 misr_reinit_iv=500 misr_reinit_lim=1000 batch_size=100 bidders=3 items=10 hidden_width=50 n_hidden=3 num_test_samples=20 attack_mode=None
 ```
 
+You can also run the experiment with parameters given by a configuration file. You can find some example configs in [baseline_configs](https://github.com/mechanism-learning-research/two-player-auctions/tree/main/baseline_configs).
+```
+# run experiment with parameters from config file
+python algnet.py with baseline_configs/config_2x2.json
+```
+```
+# run experiment with parameters from config file, overriding the number of hidden layers
+python algnet.py with baseline_configs/config_2x2.json n_hidden=5
+```
+
+### Adversarial attack simulation
+
+This implementation also includes the option to simulate adversarial attacks against the auction learner.
+There are two types of attack scenarios that can be simulated:
+- Offline attack: The adversary chooses a bidding distribution prior to to taking part in the auction, and then samples their bids from that distribution, which may not represent their true valuation profile.
+- Online attack: The adversary receives the outcome of every auction during training and can adapt their bidding strategy during every iteration of the auction.
+
+#### Offline attack
+To simulate an offline attack, set `attack_mode="offline"` as well as the `misreport_type` and the corresponding `misreport_params`.
+Currently the offline attack only supports uniform and normal distributions.
+```
+# offline attack with uniformly distributed misreports
+python algnet.py with baseline_configs/config_2x2.json attack_mode="offline" misreport_type="uniform" misreport_params="{'low': 0.0, 'high': 0.8}" num_steps=100
+```
+```
+# offline attack with normally distributed misreports
+python algnet.py with baseline_configs/config_2x2.json attack_mode="offline" misreport_type="normal" misreport_params="{'mean': 0.4, 'stddev': 0.2}" num_steps=100
+```
+
+#### Online attack
+To simulate an online attack, set `attack_mode="online"`.
+```
+python algnet.py with baseline_configs/config_2x2.json attack_mode="online" num_steps=100
+```
 
 ## Logging and Artifacts
 
@@ -34,6 +68,10 @@ The project uses the [Sacred](https://github.com/IDSIA/sacred) framework for exp
 - Logs and experiment metadata are saved to an SQLite database named `results.db`.
 - The state parameters of the last trained model are saved to `tpal_state_params.pkl`.
 
+For a quick overview over your past completed runs, you can use `db_inspect.py` to output summaries as a markdown table:
+```
+python db_inspect.py
+```
 
 ## Implementation notes
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ To simulate an online attack, set `attack_mode="online"`.
 python algnet.py with baseline_configs/config_2x2.json attack_mode="online" num_steps=100
 ```
 
+### Training with Differential Privacy
+
+You can enable differentially private stochastic gradient descent (DPSGD) by setting `dp=True` during training.
+```
+python algnet.py with baseline_configs/config_2x2.json attack_mode="online" dp=True num_steps=1000
+```
+Initial tests suggest that this aids in achieving improved auction outcomes under attack conditions, but additional experiments are needed for confirmation.
+
 ## Logging and Artifacts
 
 The project uses the [Sacred](https://github.com/IDSIA/sacred) framework for experiment tracking. 

--- a/algnet.py
+++ b/algnet.py
@@ -597,6 +597,9 @@ def training(
     log_every = num_steps // 100
 
     norm_clip_auct, norm_clip_misr = None, None
+    # If differential privacy is used, the norm clips are automatically determined
+    # by taking the median norm of the gradients during a run without differential privacy.
+    # This has been recommended in https://arxiv.org/abs/1607.00133
     if dp:
         print("#### Calibrating norm clip value for dpsgd.")
         print("Training will run for 1000 steps without differential privacy.")

--- a/algnet.py
+++ b/algnet.py
@@ -61,7 +61,7 @@ def cfg():
     rng_seed_test = 1337
     misreport_type = "uniform"  # Can be 'uniform' or 'normal'
     misreport_params = {"low": 0.0, "high": 1.0}  # Example for uniform distribution
-    attack_mode = "offline"  # Can be 'online' or 'offline' or None
+    attack_mode = "online" # Can be 'online' or 'offline' or None
     # val_dist = ...  # TODO: add when ready
 
 
@@ -386,8 +386,8 @@ class TPAL:
 
         # Build the optimizers. We use differentially private SGD.
         self.optimizers = TPALTuple(
-            auct=optax.contrib.dpsgd(learning_rate,10000,1,1),
-            misr=optax.contrib.dpsgd(learning_rate,10000,1,1),
+            auct=optax.contrib.dpsgd(learning_rate, 1.0, 1.1, 1337, 0.9, True),
+            misr=optax.contrib.dpsgd(learning_rate, 1.0, 1.1, 2342, 0.9, True),
         )
 
 

--- a/db_inspect.py
+++ b/db_inspect.py
@@ -9,7 +9,9 @@ import argparse
 
 # Add argument parser
 parser = argparse.ArgumentParser()
-parser.add_argument("--baselines-only", action="store_true", help="Check baselines only")
+parser.add_argument(
+    "--baselines-only", action="store_true", help="Check baselines only"
+)
 args = parser.parse_args()
 
 # Connect to the database
@@ -37,7 +39,7 @@ config_keys = [
     "learning_rate",
     "rng_seed_training",
     "rng_seed_test",
-    "attack_mode"
+    "attack_mode",
 ]
 
 headers = [
@@ -56,7 +58,7 @@ headers = [
     "lr",
     "seed\ntrain",
     "seed\ntest",
-    "attack"
+    "attack",
 ]
 
 rows = []
@@ -89,9 +91,20 @@ for row in cursor.fetchall():
                 continue
             # Add the data to the rows list in markdown table format
             config_data = [config[key] for key in config_keys]
-            if not args.baselines_only or (args.baselines_only and config.get("misr_updates") == 100 and config.get("num_test_samples") == 10000):
+            if not args.baselines_only or (
+                args.baselines_only
+                and config.get("misr_updates") == 100
+                and config.get("num_test_samples") == 10000
+            ):
                 rows.append(
-                    [run_id, config["bidders"], config["items"], model_score, regret, pay]
+                    [
+                        run_id,
+                        config["bidders"],
+                        config["items"],
+                        model_score,
+                        regret,
+                        pay,
+                    ]
                     + config_data
                 )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 absl-py==2.0.0
-chex==0.1.83
+chex==0.1.86
 colorama==0.4.6
 dm-haiku==0.0.10
 docopt==0.6.2
@@ -14,7 +14,7 @@ ml-dtypes==0.3.1
 munch==2.5.0
 numpy==1.26.0
 opt-einsum==3.3.0
-optax==0.1.7
+optax==0.2.2
 packaging==23.2
 py-cpuinfo==9.0.0
 sacred==0.8.4


### PR DESCRIPTION
This pull request introduces the option to train using Differentially Private Stochastic Gradient Descent (DPSGD). When differential privacy is enabled, the norm clips are automatically calculated by taking the median norm of the gradients during a run without differential privacy. The median gradient norm has been suggested as a hyperparameter in [Abadi et al (2016)](https://arxiv.org/abs/1607.00133).
To support this new feature, the `optax` and `chex` dependencies were updated to their latest versions.

Additionally, I have refactored the update functions of the `TPAL` class to call a common update function, reducing code duplication

Furthermore, some minor changes to logging have been made for better readability and improved observability of the training process. Gradient norms are now printed along with losses during training, providing additional insights into the current state of the training and the behavior of the attacker (in the attack setting).

Finally, I have updated the README file with instructions on how to use this new feature.
